### PR TITLE
Add ability to not have video autoplay within Sanity

### DIFF
--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -20,6 +20,8 @@ const Input = ({config, ...props}: InputProps): ReactElement => {
   const [open, setOpen] = useState(false)
   const onClose = useCallback(() => setOpen(false), [])
   const onOpen = useCallback(() => setOpen(true), [])
+  const autoPlay = props?.schemaType?.options?.autoplay === undefined || !!props?.schemaType?.options?.autoplay
+  const controls = !!props?.schemaType?.options?.controls
 
   return (
     <>
@@ -35,7 +37,8 @@ const Input = ({config, ...props}: InputProps): ReactElement => {
                   height: 'auto',
                   backgroundColor: 'var(--card-skeleton-color-to)',
                 }}
-                autoPlay
+                autoPlay={autoPlay}
+                controls={controls}
                 playsInline
                 muted
                 loop


### PR DESCRIPTION
controlled with `options` within the Sanity schema:

```
...
{
      name: 'verticalVideo',
      title: 'Vertical Video',
      type: 'vimeo.video',
      fieldset: 'videos',
      description: 'Vertical video currently served to the Android app',
      options: {
        autoplay: false,
        controls: true
      }
    },
...
```

if options.autoplay is not defined, the video _will_ autoplay to preserve current behavior